### PR TITLE
completely hide remote videos > 120px

### DIFF
--- a/css/videolayout_default.css
+++ b/css/videolayout_default.css
@@ -25,7 +25,7 @@
 }
 
 #remotevideos.hidden {
-    bottom: -196px;
+    bottom: -100%;
 }
 
 .videocontainer {


### PR DESCRIPTION
when FILM_STRIP_MAX_HEIGHT is set to a value greater than the default, hiding the filmstrip leaves some of the element visible.
